### PR TITLE
Small internationalization improvements

### DIFF
--- a/CovidGraphs/CovidGraphsApp.swift
+++ b/CovidGraphs/CovidGraphsApp.swift
@@ -10,13 +10,13 @@ import SwiftUI
 @main
 struct CovidGraphsApp: App {
     @AppStorage ("locations")
-    var locations: String = "Massachusetts,California,Mexico,25021.0,25025.0,Vermont"
+    var locations: String = "Massachusetts;California;Mexico;25021.0;25025.0;Vermont"
     
     func makeLocations (input: String) -> [UpdatableStat]
     {
         var res: [UpdatableStat] = []
         
-        for x in input.split(separator: ",") {
+        for x in input.split(separator: ";") {
             res.append (UpdatableStat (code: String (x)))
         }
         return res

--- a/SharedSource/CovidData.swift
+++ b/SharedSource/CovidData.swift
@@ -198,7 +198,11 @@ public class UpdatableStat: ObservableObject, Hashable, Equatable {
     }
     
     public func fetchNewSnapshot (session: URLSession? = nil){
-        let url = URL(string: "https://tirania.org/covid-data/\(code)")!
+        let urlAllowed: CharacterSet =
+            .alphanumerics.union(.init(charactersIn: "-._~")) // as per RFC 3986
+        
+        let url = URL(string: "https://tirania.org/covid-data/\(code.addingPercentEncoding(withAllowedCharacters: urlAllowed)!)")!
+        print(url)
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         


### PR DESCRIPTION
For international locations where the URL contains some URL unfriendly characters, add URL encoding before fetching data from the server and change how the list is pre-populated to support such locations. 

As it turns out, it doesn't seem like `addingPercentEncoding` has a set of allowable characters that neatly matches URL encoding so I needed to create a custom set. Perhaps I'm just being dense and missing the correct one... 

Tested against "British Columbia, Canada" and "Quebec, Canada" and a handful of others. 

_n.b. I'm a total Swift noob so please correct me on best practices!_ 